### PR TITLE
Add "Copy to Clipboard" functionality to QuickMeme editor

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -210,6 +210,7 @@
       <input type="url" id="imageUrl" placeholder="Paste image URL..." />
       <button id="loadImage">Load</button>
       <button id="addText">Add Text</button>
+      <button id="copyToClipboard">Copy to Clipboard</button>
       <button id="downloadMeme">Download</button>
     </div>
 


### PR DESCRIPTION
- Introduced a new button in the popup for copying the meme image to the clipboard.
- Implemented the copyToClipboard method to handle image rendering and clipboard operations.
- Added user feedback for successful copy action with button state changes.

<img width="618" height="308" alt="image" src="https://github.com/user-attachments/assets/21b284e8-34b6-40a0-a336-20627124755e" />
